### PR TITLE
Remove temp files from unit test

### DIFF
--- a/Tests/SwiftUIVideoExporterTests/SwiftUIVideoExporterTests.swift
+++ b/Tests/SwiftUIVideoExporterTests/SwiftUIVideoExporterTests.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 @Test func progressCallback() async throws {
     var values: [Double] = []
-    _ = try await SwiftUIVideoExporter.export(
+    let url = try await SwiftUIVideoExporter.export(
         duration: 2,
         fps: 10,
         renderSize: .init(width: 16, height: 16),
@@ -16,6 +16,7 @@ import SwiftUI
     ) { _ in
         Color.red
     }
+    try? FileManager.default.removeItem(at: url)
     #expect(values.count == 10)
     #expect(values.first == 0)
     #expect(values.last == 1)


### PR DESCRIPTION
## Summary
- delete exported video after running `progressCallback` test

## Testing
- `swift test -v` *(fails: no such module 'AVFoundation')*

------
https://chatgpt.com/codex/tasks/task_e_6863b5c62198832580940a5260bd4084